### PR TITLE
feat: support serverless@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "serverless": "^1.42.2 || ^2.0.0",
+    "serverless": "^1.42.2 || ^2.0.0 || ^3.0.0",
     "rollup": "^2.26.0"
   },
   "scripts": {


### PR DESCRIPTION
I tested compatibility in this repo: https://github.com/perrin4869/serverless2-rollup-test
This PR adds support for the newly released serverless 3.0