### PR TITLE
Remove assets release

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -4,9 +4,4 @@ plugins:
   - "@semantic-release/release-notes-generator"
   - "@semantic-release/changelog"
   - "@semantic-release/npm"
-  - - "@semantic-release/github"
-    - assets:
-        - path: dist/**
-          label: "Distribution"
-        - path: CHANGELOG.md
-          label: "Changelog"
+  - "@semantic-release/github"


### PR DESCRIPTION
I noticed every file in the `dist` directory was being pushed to the assets in the release page after publish. That doesn't seem very useful haha