### PR TITLE
docs: update readme to note package individually

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ plugins:
   - ...any other plugins
 ```
 
+Make sure you have package individually turned on:
+```yaml
+package:
+  individually: true
+```
+
 For each function that you would like to use rollup option, just define the handler option as normal. You can
 optionally define the `dependencies` property as a list of packages to be installed in the `node_modules` folder
 in your lambda.


### PR DESCRIPTION
Just tried out this package and it was failing with a `No service.zip file found in the package path you provided.`

I found out it only works when package individually is turned on. 