### PR TITLE
chore(semantic-release): fix repository url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Welcome to serverless-rollup-plugin 👋
 
-[![Release](https://github.com/drg-adaptive/serverless-rollup-plugin/workflows/Release/badge.svg)](https://github.com/drg-adaptive/serverless-rollup-plugin/actions)
-[![Maintainability](https://api.codeclimate.com/v1/badges/79e200bf72d884691c7a/maintainability)](https://codeclimate.com/github/drg-adaptive/serverless-rollup-plugin/maintainability)
+[![Release](https://github.com/theBenForce/serverless-rollup-plugin/workflows/Release/badge.svg)](https://github.com/theBenForce/serverless-rollup-plugin/actions)
+[![Maintainability](https://api.codeclimate.com/v1/badges/79e200bf72d884691c7a/maintainability)](https://codeclimate.com/github/theBenForce/serverless-rollup-plugin/maintainability)
 [![npm version](https://badge.fury.io/js/serverless-rollup-plugin.svg)](https://badge.fury.io/js/serverless-rollup-plugin)
-[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fdrg-adaptive%2Fserverless-rollup-plugin.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fdrg-adaptive%2Fserverless-rollup-plugin?ref=badge_shield)
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2FtheBenForce%2Fserverless-rollup-plugin.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2FtheBenForce%2Fserverless-rollup-plugin?ref=badge_shield)
 [![All Contributors](https://img.shields.io/github/all-contributors/theBenForce/serverless-rollup-plugin?color=ee8449&style=flat-square)](#contributors)
 
 > A plugin for the serverless framework to bundle lambda code using rollup

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "name": "Ben Force",
     "email": "bforce@teamdrg.com"
   },
-  "homepage": "https://github.com/drg-adaptive/serverless-rollup-plugin",
-  "repository": "github:drg-adaptive/serverless-rollup-plugin",
-  "bugs": "https://github.com/drg-adaptive/serverless-rollup-plugin/issues",
+  "homepage": "https://github.com/theBenForce/serverless-rollup-plugin",
+  "repository": "github:theBenForce/serverless-rollup-plugin",
+  "bugs": "https://github.com/theBenForce/serverless-rollup-plugin/issues",
   "license": "MIT",
   "devDependencies": {
     "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",


### PR DESCRIPTION
https://github.com/theBenForce/serverless-rollup-plugin/actions/runs/10658003967/job/29538528492