### PR TITLE
fix: use updated license key variable

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Run Tests
         run: npm test
         env:
-          SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
+          SERVERLESS_LICENSE_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           LAMBDA_NODE_VERSION: nodejs${{ matrix.node-version }}


### PR DESCRIPTION
Setting the license key using the environment variable provided in the docs.

## References
- https://www.serverless.com/framework/docs/guides/license-keys#how-to-use-license-keys